### PR TITLE
Added acceptedEncodings and contentCharset fields (with getter/setter) to HttpClient

### DIFF
--- a/src/org/pixmob/httpclient/HttpClient.java
+++ b/src/org/pixmob/httpclient/HttpClient.java
@@ -41,10 +41,14 @@ public final class HttpClient {
     }
 
     private static final String DEFAULT_USER_AGENT = getDefaultUserAgent();
+    private static final String DEFAULT_CONTENT_CHARSET = "UTF-8";
+    private static final String DEFAULT_ACCEPTED_ENCODINGS = "gzip,deflate";
     private final Context context;
     private int connectTimeout;
     private int readTimeout;
     private String userAgent;
+    private String contentCharset;
+    private String acceptedEncodings;
     private final Map<String, String> inMemoryCookies = new HashMap<String, String>(8);
 
     /**
@@ -160,6 +164,40 @@ public final class HttpClient {
      */
     public void setUserAgent(String userAgent) {
         this.userAgent = userAgent;
+    }
+
+    /**
+     * Get the accepted character set to encode content in with every request.
+     */
+    public String getContentCharset() {
+        if (contentCharset == null) {
+            return DEFAULT_CONTENT_CHARSET;
+        }
+        return contentCharset;
+    }
+
+    /**
+     * Set the accepted character set to encode content in with every request.
+     */
+    public void setContentCharset(String contentCharset) {
+        this.contentCharset = contentCharset;
+    }
+
+    /**
+     * Get the accepted encodings for every request.
+     */
+    public String getAcceptedEncodings() {
+        if (acceptedEncodings == null) {
+            return DEFAULT_ACCEPTED_ENCODINGS;
+        }
+        return acceptedEncodings;
+    }
+
+    /**
+     * Set the accepted encodings for every request.
+     */
+    public void setAcceptedEncodings(String acceptedEncodings) {
+        this.acceptedEncodings = acceptedEncodings;
     }
 
     Map<String, String> getInMemoryCookies() {

--- a/src/org/pixmob/httpclient/HttpRequestBuilder.java
+++ b/src/org/pixmob/httpclient/HttpRequestBuilder.java
@@ -64,7 +64,6 @@ import android.os.Build;
  */
 public final class HttpRequestBuilder {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-    private static final String CONTENT_CHARSET = "UTF-8";
     private static final Map<String, List<String>> NO_HEADERS = new HashMap<String, List<String>>(0);
     private static TrustManager[] trustManagers;
     private final byte[] buffer = new byte[1024];
@@ -209,15 +208,15 @@ public final class HttpRequestBuilder {
                     }
                     final String name = e.getKey();
                     final String value = e.getValue();
-                    buf.append(URLEncoder.encode(name, CONTENT_CHARSET)).append("=")
-                            .append(URLEncoder.encode(value, CONTENT_CHARSET));
+                    buf.append(URLEncoder.encode(name, hc.getContentCharset())).append("=")
+                            .append(URLEncoder.encode(value, hc.getContentCharset()));
                     ++paramIdx;
                 }
 
                 if (!contentSet
                         && (HTTP_POST.equals(method) || HTTP_DELETE.equals(method) || HTTP_PUT.equals(method))) {
                     try {
-                        content = buf.toString().getBytes(CONTENT_CHARSET);
+                        content = buf.toString().getBytes(hc.getContentCharset());
                     } catch (UnsupportedEncodingException e) {
                         // Unlikely to happen.
                         throw new HttpClientException("Encoding error", e);
@@ -264,8 +263,8 @@ public final class HttpRequestBuilder {
             conn.setRequestProperty("Connection", "close");
             conn.setRequestProperty("Location", uri);
             conn.setRequestProperty("Referrer", uri);
-            conn.setRequestProperty("Accept-Encoding", "gzip,deflate");
-            conn.setRequestProperty("Accept-Charset", CONTENT_CHARSET);
+            conn.setRequestProperty("Accept-Encoding", hc.getAcceptedEncodings());
+            conn.setRequestProperty("Accept-Charset", hc.getContentCharset());
 
             if (conn instanceof HttpsURLConnection) {
                 setupSecureConnection(hc.getContext(), (HttpsURLConnection) conn);
@@ -276,7 +275,7 @@ public final class HttpRequestBuilder {
                     conn.setDoOutput(true);
                     if (!contentSet) {
                         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset="
-                                + CONTENT_CHARSET);
+                                + hc.getContentCharset());
                     } else if (contentType != null) {
                         conn.setRequestProperty("Content-Type", contentType);
                     }


### PR DESCRIPTION
To support non-default server encodings, this update allows setting of accepted content encodings and character sets to any http request. See issue 6.
