### PR TITLE
Ensure http request action is always work asynchronously(Use AsyncTask).

### DIFF
--- a/src/org/pixmob/httpclient/GoogleAppEngineAuthenticator.java
+++ b/src/org/pixmob/httpclient/GoogleAppEngineAuthenticator.java
@@ -68,8 +68,8 @@ public class GoogleAppEngineAuthenticator extends AbstractAccountAuthenticator {
         final HttpClient hc = new HttpClient(getContext());
         final HttpResponse resp;
         try {
-            resp = hc.get(loginUrl).expect(HttpURLConnection.HTTP_MOVED_TEMP).execute();
-        } catch (HttpClientException e) {
+            resp = hc.get(loginUrl).expect(HttpURLConnection.HTTP_MOVED_TEMP).execute().get();
+        } catch (Exception e) {
             throw new HttpClientException("Authentication failed", e);
         }
 

--- a/src/org/pixmob/httpclient/HttpRequestBuilder.java
+++ b/src/org/pixmob/httpclient/HttpRequestBuilder.java
@@ -21,6 +21,9 @@ import static org.pixmob.httpclient.Constants.HTTP_HEAD;
 import static org.pixmob.httpclient.Constants.HTTP_POST;
 import static org.pixmob.httpclient.Constants.HTTP_PUT;
 
+import android.os.AsyncTask;
+import android.os.Build;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -62,7 +65,7 @@ import android.os.Build;
  * This class is used to prepare and execute an Http request.
  * @author Pixmob
  */
-public final class HttpRequestBuilder {
+public final class HttpRequestBuilder  extends AsyncTask<Void, Integer, HttpResponse> {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String CONTENT_CHARSET = "UTF-8";
     private static final Map<String, List<String>> NO_HEADERS = new HashMap<String, List<String>>(0);
@@ -192,7 +195,7 @@ public final class HttpRequestBuilder {
         return this;
     }
 
-    public HttpResponse execute() throws HttpClientException {
+    public HttpResponse executeRequest() throws HttpClientException {
         HttpURLConnection conn = null;
         UncloseableInputStream payloadStream = null;
         try {
@@ -399,6 +402,16 @@ public final class HttpRequestBuilder {
         }
     }
 
+    @Override
+    protected HttpResponse doInBackground(Void... params) {
+        HttpResponse httpResponse = null;
+        try {
+            httpResponse = this.executeRequest();
+        } catch (HttpClientException e) {
+            e.printStackTrace();
+        }
+        return httpResponse;
+    }
     /**
      * Open the {@link InputStream} of an Http response. This method supports
      * GZIP and DEFLATE responses.


### PR DESCRIPTION
In Android land, should not use network action in UI thread. 
If it uses in Main Thread, it will occur `android.os.NetworkOnMainThreadException`

To be sure, `HttpRequestBuilder` class should modify to subclass AsyncTask and implement the doInBackground() callback method, which runs in a pool of background threads.
